### PR TITLE
Fix for missing font

### DIFF
--- a/osm-liberty.json
+++ b/osm-liberty.json
@@ -1252,7 +1252,7 @@
       "layout": {
         "text-field": "{house_num}",
         "text-font": [
-          "Roboto Condensed"
+          "Roboto Condensed Regular"
         ],
         "text-max-width": 7,
         "text-size": 9.5,


### PR DESCRIPTION
"Roboto Condensed" doesn't exist in [./fonts](https://github.com/lukasmartinelli/osm-liberty/tree/gh-pages/fonts), I'm assuming "Roboto Condensed Regular" is the correct font
