### PR TITLE
Fixed font issues in Roboto glyphs

### DIFF
--- a/osm-liberty.json
+++ b/osm-liberty.json
@@ -85,7 +85,7 @@
     }
   },
   "sprite": "http://osm-liberty.lukasmartinelli.ch/sprites/osm-liberty",
-  "glyphs": "http://osm-liberty.lukasmartinelli.ch/fonts/{fontstack}/{range}.pbf",
+  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",


### PR DESCRIPTION
Fixed font issues in Roboto glyphs, by switching source to https://github.com/orangemug/font-glyphs

Fixes issue #1
