### PR TITLE
Revert Mapbox GL back to v0.29.0 until v0.32.0 is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To use it you don't need any access keys and you can host the tiles and assets y
     body { margin:0; padding:0; }
     #map { position:absolute; top:0; bottom:0; width:100%; }
   </style>
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.css' rel='stylesheet' />
 </head>
 <body>
   <div id='map'></div>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use it you don't need any access keys and you can host the tiles and assets y
   <script>
   var map = new mapboxgl.Map({
       container: 'map',
-      style: 'http://osm-liberty.lukasmartinelli.ch/osm-liberty.json',
+      style: 'http://osm-liberty.lukasmartinelli.ch/style.json',
       center: [8.538961,47.372476],
       zoom: 5,
       hash: true

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     #map { position:absolute; top:0; bottom:0; width:100%; }
     #github-button { position: absolute; top: 15px; left: 15px; z-index: 1000; }
   </style>
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.29.0/mapbox-gl.css' rel='stylesheet' />
 </head>
 <body>
   <iframe id="github-button" src="https://ghbtns.com/github-btn.html?user=lukasmartinelli&amp;repo=osm-liberty&amp;type=star&amp;count=true&amp;size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.30.0/mapbox-gl.css' rel='stylesheet' />
 </head>
 <body>
-  <iframe id="github-button" src="https://ghbtns.com/github-btn.html?user=lukasmartinelli&repo=osm-liberty&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+  <iframe id="github-button" src="https://ghbtns.com/github-btn.html?user=lukasmartinelli&amp;repo=osm-liberty&amp;type=star&amp;count=true&amp;size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
   <div id='map'></div>
   <script>
   var map = new mapboxgl.Map({


### PR DESCRIPTION
This PR contains the following three changes:
* 0843f3a rename the style filename in the example code of the README
* 4939822 encode & as &amp; in HTML-attribute
* 37a967c revert Mapbox GL back to v0.29.0 until v0.32.0 is released. That's because v0.30.0 and v0.31.0 won't display the map in Firefox if the browser window gets larger than 2048px in width or height (for details see the commit message)