### PR TITLE
Removed 'ramp' filter from 'road_trunk_primary_casing' layer

### DIFF
--- a/style.json
+++ b/style.json
@@ -1497,11 +1497,6 @@
           "class",
           "primary",
           "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
         ]
       ],
       "layout": {


### PR DESCRIPTION
On ramps were missing their casing, which looked odd.

Before
<img width="716" alt="screen shot 2018-02-18 at 12 43 51" src="https://user-images.githubusercontent.com/235915/36351983-726b3e8c-14a9-11e8-966c-c98d71265b1d.png">
After
<img width="714" alt="screen shot 2018-02-18 at 12 43 36" src="https://user-images.githubusercontent.com/235915/36351984-73e516e8-14a9-11e8-984a-d24b88d3aa36.png">

**Warning:** I have no idea if this was an intentional filter and has other side effects.
