### PR TITLE
Fixed road_trunk_primary into tunnel_trunk_primary

### DIFF
--- a/style.json
+++ b/style.json
@@ -1505,7 +1505,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       },
@@ -1891,7 +1891,7 @@
         ]
       ],
       "layout": {
-        "line-cap": "round",
+        "line-cap": "butt",
         "line-join": "round",
         "visibility": "visible"
       }


### PR DESCRIPTION
Fixed the join from `road_trunk_primary` into `tunnel_trunk_primary`

Before

<img width="682" alt="screen shot 2018-02-25 at 18 26 44" src="https://user-images.githubusercontent.com/235915/36644949-7f27691a-1a59-11e8-9c6e-3b3802e8ce59.png">

After

<img width="675" alt="screen shot 2018-02-25 at 18 26 28" src="https://user-images.githubusercontent.com/235915/36644953-84ebe68c-1a59-11e8-9c67-45b410cf8c53.png">

Reference: <https://maputnik.github.io/editor/?style=https://rawgit.com/lukasmartinelli/osm-liberty/gh-pages/style.json#18.27/53.409324/-2.984545>
