### PR TITLE
removed key, updated sprite path

### DIFF
--- a/style.json
+++ b/style.json
@@ -16,10 +16,10 @@
     },
     "openmaptiles": {
       "type": "vector",
-      "url": "https://free.tilehosting.com/data/v3.json?key=tXiQqN3lIgskyDErJCeY"
+      "url": "https://free.tilehosting.com/data/v3.json?key={key}"
     }
   },
-  "sprite": "https://rawgit.com/lukasmartinelli/osm-liberty/gh-pages/sprites/osm-liberty",
+  "sprite": "https://rawgit.com/maputnik/osm-liberty/gh-pages/sprites/osm-liberty",
   "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
   "layers": [
     {


### PR DESCRIPTION
The existing tilehosting key is not valid anymore, replaced with `{key}` to make OSM Liberty working again on https://maputnik.github.io/editor/ after https://github.com/maputnik/editor/pull/333 is merged.