### PR TITLE
Update vector source URL

### DIFF
--- a/style.json
+++ b/style.json
@@ -16,7 +16,7 @@
     },
     "openmaptiles": {
       "type": "vector",
-      "url": "https://free.tilehosting.com/data/v3.json?key={key}"
+      "url": "https://maps.tilehosting.com/data/v3.json?key={key}"
     }
   },
   "sprite": "https://rawgit.com/maputnik/osm-liberty/gh-pages/sprites/osm-liberty",


### PR DESCRIPTION
To prevent confusion - `free` is working, but `maps` is what Maptiler Cloud shows as URL in the dataset settings.