### PR TITLE
Change default for glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A free Mapbox GL basemap style for everyone with complete liberty to use and sel
 
 You can use the style in your Mapbox GL maps. 
 
-By default, the vector tiles are served from [Maptiler Cloud](https://www.maptiler.com/cloud/) and the raster tiles, glyphs and sprites directly from GitHub.
-You would need to [subscribe](https://www.maptiler.com/cloud/plans) to Maptiler Cloud to get an access key and replace the placeholder {key} [here](https://github.com/maputnik/osm-liberty/blob/gh-pages/style.json#L19) with your own key.
+By default, the vector tiles and glyphs are served from [Maptiler Cloud](https://www.maptiler.com/cloud/) and the raster tiles and sprites directly from GitHub.
+You would need to [subscribe](https://www.maptiler.com/cloud/plans) to Maptiler Cloud to get an access key and replace the placeholder {key} for the [vector source](https://github.com/maputnik/osm-liberty/blob/gh-pages/style.json#L11) and [glyphs](https://github.com/maputnik/osm-liberty/blob/gh-pages/style.json#L23) with your own key.
 
 
 Another option is to create your own vector tiles with [OpenMapTiles](https://github.com/openmaptiles/openmaptiles) and host the tiles and assets yourself for complete liberty.

--- a/style.json
+++ b/style.json
@@ -20,7 +20,7 @@
     }
   },
   "sprite": "https://rawgit.com/maputnik/osm-liberty/gh-pages/sprites/osm-liberty",
-  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "glyphs": "https://maps.tilehosting.com/fonts/{fontstack}/{range}.pbf?key={key}",
   "layers": [
     {
       "id": "background",


### PR DESCRIPTION
Change default for glyphs to have font metadata available, for details see: https://github.com/maputnik/osm-liberty/issues/36