### PR TITLE
Update sprite URL rawgit.com -> GitHub Pages

### DIFF
--- a/style.json
+++ b/style.json
@@ -19,7 +19,7 @@
       "type": "raster"
     }
   },
-  "sprite": "https://rawgit.com/maputnik/osm-liberty/gh-pages/sprites/osm-liberty",
+  "sprite": "https://maputnik.github.io/osm-liberty/sprites/osm-liberty",
   "glyphs": "https://maps.tilehosting.com/fonts/{fontstack}/{range}.pbf?key={key}",
   "layers": [
     {


### PR DESCRIPTION
Ref: https://github.com/maputnik/editor/issues/412

GitHub Pages is available for the OSM Liberty sprite, so we could use it instead of jsdelivr.net.