### PR TITLE
Removed unneeded two-level filter.

### DIFF
--- a/style.json
+++ b/style.json
@@ -2249,18 +2249,15 @@
           "LineString"
         ],
         [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "minor"
-          ]
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "minor"
         ]
       ],
       "layout": {


### PR DESCRIPTION
I don't know if layer "road_minor-copy" is actually used but if it is, there is an unneeded complication in its filter, which has two levels of "all" tests:
```
      "filter": [
        "all",
        [
          "==",
          "$type",
          "LineString"
        ],
        [
          "all",
          [
            "!in",
            "brunnel",
            "bridge",
            "tunnel"
          ],
          [
            "in",
            "class",
            "minor"
          ]
        ]
```
This PR removes the nested array.