### PR TITLE
fix bad link on style.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <script>
   var map = new mapboxgl.Map({
       container: 'map',
-      style: '/style.json',
+      style: '/osm-liberty/style.json',
       center: [8.538961,47.372476],
       zoom: 5,
       hash: true


### PR DESCRIPTION
Hello, 
The page https://maputnik.github.io/osm-liberty/ is blank, the `style.json` request fails with a 404. 
This PR should fix it by adding the correct prefix that is missing.
