### PR TITLE
Change minzoom for layer boundary_3

### DIFF
--- a/style.json
+++ b/style.json
@@ -3245,6 +3245,7 @@
       "metadata": {},
       "source": "openmaptiles",
       "source-layer": "boundary",
+      "minzoom": 8,
       "filter": [
         "all",
         [


### PR DESCRIPTION
Closes #41 
Maybe we could use a lower `minzoom` again after https://github.com/openmaptiles/openmaptiles/issues/549 is solved.

Before:
![before](https://user-images.githubusercontent.com/20856381/66695876-c1c36a80-ecc6-11e9-9a48-154203dd1f01.png)

This PR:
![this_pr](https://user-images.githubusercontent.com/20856381/66695875-c1c36a80-ecc6-11e9-8cb1-ca74bc3f3b50.png)


