### PR TITLE
ramp property is an integer, not a string

### DIFF
--- a/style.json
+++ b/style.json
@@ -243,7 +243,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "ramp", "1"], ["==", "brunnel", "tunnel"]],
+      "filter": ["all", ["==", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {"line-join": "round"},
       "paint": {
         "line-color": "#e9ac77",
@@ -386,7 +386,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "ramp", "1"], ["==", "brunnel", "tunnel"]],
+      "filter": ["all", ["==", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {"line-join": "round"},
       "paint": {
         "line-color": "#fff4c6",
@@ -565,7 +565,7 @@
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
         ["!in", "class", "pedestrian", "path", "track", "service"],
-        ["==", "ramp", "1"]
+        ["==", "ramp", 1]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -586,7 +586,7 @@
         ["==", "$type", "LineString"],
         ["!in", "brunnel", "bridge", "tunnel"],
         ["in", "class", "minor"],
-        ["!=", "ramp", "1"]
+        ["!=", "ramp", 1]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -644,7 +644,7 @@
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
         ["==", "class", "motorway"],
-        ["!=", "ramp", "1"]
+        ["!=", "ramp", 1]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {


### PR DESCRIPTION
Hello, 
The filtering on the `ramp` does not work because of the string comparison instead of an integer.
This PR fixes it.