### PR TITLE
Fix motorway ramp/link style

### DIFF
--- a/style.json
+++ b/style.json
@@ -352,7 +352,7 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "class", "motorway_link"],
+        ["==", "class", "motorway"],
         ["==", "ramp", 1],
         ["==", "brunnel", "tunnel"]
       ],
@@ -871,7 +871,7 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "class", "motorway_link"],
+        ["==", "class", "motorway"],
         ["==", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],
@@ -1030,7 +1030,7 @@
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "class", "motorway_link"],
+        ["==", "class", "motorway"],
         ["==", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],

--- a/style.json
+++ b/style.json
@@ -316,6 +316,7 @@
       "filter": [
         "all",
         ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
         ["==", "brunnel", "tunnel"]
       ],
       "layout": {"line-join": "round"},
@@ -448,6 +449,7 @@
       "filter": [
         "all",
         ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
         ["==", "brunnel", "tunnel"]
       ],
       "layout": {"line-join": "round"},
@@ -564,7 +566,7 @@
       "filter": [
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["!in", "class", "pedestrian", "path", "track", "service"],
+        ["!in", "class", "pedestrian", "path", "track", "service", "motorway"],
         ["==", "ramp", 1]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
@@ -721,7 +723,7 @@
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
         ["==", "ramp", 1],
-        ["!in", "class", "pedestrian", "path", "track", "service"]
+        ["!in", "class", "pedestrian", "path", "track", "service", "motorway"]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -995,6 +997,7 @@
       "filter": [
         "all",
         ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],
       "layout": {"line-join": "round"},
@@ -1126,6 +1129,7 @@
       "filter": [
         "all",
         ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],
       "layout": {"line-join": "round"},


### PR DESCRIPTION
Minor fixes on motorway links. 

- the `motorway_link` value does not exists in the transportation class property.
  see https://github.com/openmaptiles/openmaptiles/blob/master/layers/transportation/class.sql#L14

- some styles are duplicated between ramps and links. 

  ![motorway duplicates](https://user-images.githubusercontent.com/1412193/69645316-46dfc480-1066-11ea-9bf6-6e78f12cda5b.png)

before/after this PR: 

![image](https://user-images.githubusercontent.com/1412193/69645720-ea30d980-1066-11ea-840c-ec85f5eaf812.png)
![image](https://user-images.githubusercontent.com/1412193/69645874-28c69400-1067-11ea-8e48-6762ab9474c3.png)


   