### PR TITLE
Fix water_name_line source layer

### DIFF
--- a/style.json
+++ b/style.json
@@ -1257,7 +1257,7 @@
       "id": "water_name_line",
       "type": "symbol",
       "source": "openmaptiles",
-      "source-layer": "water_name",
+      "source-layer": "waterway",
       "filter": ["all", ["==", "$type", "LineString"]],
       "layout": {
         "text-field": "{name}",


### PR DESCRIPTION
The `water_name` layer only contains labeling points for [lake bodies](https://openmaptiles.org/schema/#water_name). To correctly label rivers, the source needs to be set to waterway, which has a `name` field from OSM.

Before, no labels on rivers, after:
![image](https://user-images.githubusercontent.com/15164633/70749928-9c64d400-1cea-11ea-9b6c-9bb87438f17d.png)
