### PR TITLE
Add styling for landcover, class==ice

### DIFF
--- a/style.json
+++ b/style.json
@@ -97,6 +97,20 @@
       }
     },
     {
+      "id": "landcover_ice",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "maxzoom": 24,
+      "filter": ["all", ["==", "class", "ice"]],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "rgba(224, 236, 236, 1)",
+        "fill-opacity": 0.8
+      }
+    },
+    {
       "id": "landuse_cemetery",
       "type": "fill",
       "source": "openmaptiles",

--- a/style.json
+++ b/style.json
@@ -101,9 +101,7 @@
       "type": "fill",
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "maxzoom": 24,
       "filter": ["all", ["==", "class", "ice"]],
-      "layout": {"visibility": "visible"},
       "paint": {
         "fill-antialias": false,
         "fill-color": "rgba(224, 236, 236, 1)",


### PR DESCRIPTION
Adds styling for `class==ice` in the landcover layer. This takes the glacier color from the [default OSM style](https://www.openstreetmap.org/#map=15/41.4103/-122.2029).

For [Mt. Rainier (preview)](https://maputnik.github.io/editor/?style=https://raw.githubusercontent.com/kylebarron/osm-liberty/landcover-ice/style.json#11/46.8575/-121.7126):

Before:
![image](https://user-images.githubusercontent.com/15164633/72018654-17f86900-3236-11ea-80cc-751d595179f5.png)

After:
![image](https://user-images.githubusercontent.com/15164633/72018626-10d15b00-3236-11ea-83ea-ca42a579efbb.png)
