### PR TITLE
Add compatible OMT version to metadata

### DIFF
--- a/style.json
+++ b/style.json
@@ -3,7 +3,8 @@
   "name": "OSM Liberty",
   "metadata": {
     "maputnik:license": "https://github.com/maputnik/osm-liberty/blob/gh-pages/LICENSE.md",
-    "maputnik:renderer": "mbgljs"
+    "maputnik:renderer": "mbgljs",
+    "openmaptiles:version": "3.x"
   },
   "sources": {
     "openmaptiles": {


### PR DESCRIPTION
This metadata entry defines compatibility to the OpenMapTiles schema version.