### PR TITLE
Fix icon names in json

### DIFF
--- a/iconset.json
+++ b/iconset.json
@@ -2901,7 +2901,7 @@
           ],
           "width": 15
         },
-        "town-hall_11.svg": {
+        "town_hall_11.svg": {
           "height": 11,
           "pathData": [
             {
@@ -2916,7 +2916,7 @@
           ],
           "width": 11
         },
-        "town-hall_15.svg": {
+        "town_hall_15.svg": {
           "height": 15,
           "pathData": [
             {


### PR DESCRIPTION
In https://github.com/maputnik/osm-liberty/commit/7efca5a5d82b4ecd0f3fd7ce868a6f43c3a54ecb#diff-2756c430ec9e8e2dd95dee3c4193b2bde1f2ded037fbce487d9b6a6296de50d5 a icon was renamed without changing it in the ground truth json file.