### PR TITLE
Use "npm ci"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
     - run: npm run validate
     - run: npm run diff


### PR DESCRIPTION
Use `npm ci` instead `npm install` for GH-Actions, see https://docs.npmjs.com/cli/v8/commands/npm-ci.