### PR TITLE
Add layers for landuse track and pitch (fixes #91)

### DIFF
--- a/style.json
+++ b/style.json
@@ -110,6 +110,22 @@
       }
     },
     {
+      "id": "landuse_pitch",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "pitch"],
+      "paint": {"fill-color": "#DEE3CD"}
+    },
+    {
+      "id": "landuse_track",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "track"],
+      "paint": {"fill-color": "#DEE3CD"}
+    },
+    {
       "id": "landuse_cemetery",
       "type": "fill",
       "source": "openmaptiles",


### PR DESCRIPTION
Fix issue #91 by adding two layers.

| Before | After |
|--------|--------|
| ![image](https://github.com/maputnik/osm-liberty/assets/242172/fbcc90fa-1331-4ce0-9823-435b49a4f148) | ![image](https://github.com/maputnik/osm-liberty/assets/242172/fe89107d-14ef-45d3-9117-1babcfd81825) |
| ![image](https://github.com/maputnik/osm-liberty/assets/242172/88caf17b-9d6f-4a02-8ee2-f1c9b7dbd55e) | ![image](https://github.com/maputnik/osm-liberty/assets/242172/8c4604eb-207c-45ac-9f47-6b72cdc2928c) |