### PR TITLE
only show road shield where relevant

### DIFF
--- a/style.json
+++ b/style.json
@@ -1530,7 +1530,15 @@
       "source": "openmaptiles",
       "source-layer": "transportation_name",
       "minzoom": 7,
-      "filter": ["all", ["<=", "ref_length", 6]],
+      "filter": 
+         ["all", ["<=", ["get", "ref_length"], 6],
+         ["case",
+           ["<", ["zoom"], 12],
+           ["!=", ["get", "subclass"], "junction"],
+		     ["!=", ["get", "class"], "path"],
+         ["!=", ["get", "class"], "track"],
+         true
+        ]
       "layout": {
         "icon-image": "default_{ref_length}",
         "icon-rotation-alignment": "viewport",


### PR DESCRIPTION
* this hides the shield of junctions unless zoomed in
* it hides the (relatively common) case of paths & tracks getting a ref. This is almost always incorrectly used, or it just applies to the former railway that used to go there